### PR TITLE
Make it work with multiple sites

### DIFF
--- a/jspm-hot-reloader.js
+++ b/jspm-hot-reloader.js
@@ -2,8 +2,12 @@ import socketIO from 'socket.io-client'
 import Emitter from 'weakee'
 import cloneDeep from 'lodash.clonedeep'
 
+function identity (value) {
+  return value
+}
+
 class JspmHotReloader extends Emitter {
-  constructor (backendUrl) {
+  constructor (backendUrl, transform = identity) {
     super()
     this.socket = socketIO(backendUrl)
     this.socket.on('connect', () => {
@@ -11,7 +15,7 @@ class JspmHotReloader extends Emitter {
       this.socket.emit('identification', navigator.userAgent)
     })
     this.socket.on('change', (ev) => {
-      let moduleName = ev.path.replace(document.location.pathname.slice(1), '')
+      let moduleName = transform(ev.path)
       this.emit('change', moduleName)
       if (moduleName === 'index.html') {
         document.location.reload(true)

--- a/jspm-hot-reloader.js
+++ b/jspm-hot-reloader.js
@@ -11,7 +11,7 @@ class JspmHotReloader extends Emitter {
       this.socket.emit('identification', navigator.userAgent)
     })
     this.socket.on('change', (ev) => {
-      let moduleName = ev.path
+      let moduleName = ev.path.replace(location.pathname.slice(1), '')
       this.emit('change', moduleName)
       if (moduleName === 'index.html') {
         document.location.reload(true)

--- a/jspm-hot-reloader.js
+++ b/jspm-hot-reloader.js
@@ -11,7 +11,7 @@ class JspmHotReloader extends Emitter {
       this.socket.emit('identification', navigator.userAgent)
     })
     this.socket.on('change', (ev) => {
-      let moduleName = ev.path.replace(location.pathname.slice(1), '')
+      let moduleName = ev.path.replace(document.location.pathname.slice(1), '')
       this.emit('change', moduleName)
       if (moduleName === 'index.html') {
         document.location.reload(true)


### PR DESCRIPTION
The idea is to have a single node instance handling multiple sites
where each site has it's own directory structure.
This is especially useful for development where you don't want to
install and setup a full web server (like Apache or Nginx).

In this setup, you want to pass the sites to chokidar so that when
files change, the page is hot reloaded.

Suppose we have two sites:
- one
- two

When we change the file _one/app.js_, the emitted event will receive
the full path, i.e. _one/app.js_, while the hot reloader expect to
have a path without the prefix (in this case, _one/_).

This commit remove the prefix from the path so that the hot reloader
works as expected.

I've also created a small example to show how this works:
https://github.com/oligot/jspm-hot-reloader-multiple