### PR TITLE
Call __reload hook with deletedModule

### DIFF
--- a/jspm-hot-reloader.js
+++ b/jspm-hot-reloader.js
@@ -184,8 +184,8 @@ class JspmHotReloader extends Emitter {
         return this.originalSystemImport.call(System, moduleName).then(moduleReloaded => {
           console.log('reimported ', moduleName)
           if (typeof moduleReloaded.__reload === 'function') {
-            const deletedModule = this.modulesJustDeleted[moduleName];
-            if(deletedModule !== undefined) {
+            const deletedModule = this.modulesJustDeleted[moduleName]
+            if (deletedModule !== undefined) {
               moduleReloaded.__reload(deletedModule.exports) // calling module reload hook
             }
           }

--- a/jspm-hot-reloader.js
+++ b/jspm-hot-reloader.js
@@ -183,6 +183,12 @@ class JspmHotReloader extends Emitter {
       const promises = toReimport.map((moduleName) => {
         return this.originalSystemImport.call(System, moduleName).then(moduleReloaded => {
           console.log('reimported ', moduleName)
+          if (typeof moduleReloaded.__reload === 'function') {
+            const deletedModule = this.modulesJustDeleted[moduleName];
+            if(deletedModule !== undefined) {
+              moduleReloaded.__reload(deletedModule.exports) // calling module reload hook
+            }
+          }
         })
       })
       return Promise.all(promises).then(() => {


### PR DESCRIPTION
Allowing one to restore state on hot reload.

Very basic usage example:
``` javascript
var state = [];
export function addItem(text) {
  state.push(text);
}
export function removeItem(text) {
  state = state.filter(item => item != text)
}
export function getItems() {
  return state;
}
window.addItem = addItem;
window.removeItem = removeItem;
window.getItems = getItems;

export function __reload(deletedModule){
  console.log('__reload');
  state = deletedModule.getItems();
  console.log('  restored items: ', state);
}

```